### PR TITLE
Opt-in HSTS

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -17,6 +17,9 @@
 	# auto redirect http -> https
 	RewriteCond %{HTTPS} off
 	RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+	# HTTP Strict Transport Security (HSTS)
+	Header always set Strict-Transport-Security "max-age=300;"
 </IfModule>
 
 # control "max-age" & "Cache-Control" in HTTP header


### PR DESCRIPTION
Summary:
A security feature that lets a web site tell browsers that it should only be communicated with using HTTPS, instead of using HTTP.

* Now using a short 5 min for testing, will ramp up to 1 year gradually later.
* **Don't bother** submit our domain to https://hstspreload.org/. Currently we do not comply with all rules.

MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
A longer read: http://www.aspectsecurity.com/blog/http-strict-transport-security