### PR TITLE
Rename Mac OS X & OSX to macOS

### DIFF
--- a/download.php
+++ b/download.php
@@ -84,7 +84,7 @@
   <div>
     <p>
       <strong>Current version: qBittorrent v4.1.0</strong><br/><br/>
-      <strong>May work on older OSX versions. If not, recompile with older Qt version.</strong>
+      <strong>May work on older macOS versions. If not, recompile with older Qt version.</strong>
     </p>
     <p>
       <strong>Download link: <a href="https://www.fosshub.com/qBittorrent.html">DMG</a> / <a href="https://www.fosshub.com/qBittorrent.html">PGP signature</a></strong> (FossHub)<br/>

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@
 <a href="download.php"><img src="img/QBt-download-150.png" alt="download link" style="float: left; margin-right: 10px; height: 115px;"/></a>
 The qBittorrent project aims to provide an open-source software alternative to µTorrent.
 
-Additionally, qBittorrent runs and provides the same features on all major platforms (Linux, Mac OS X, Windows, OS/2, FreeBSD).
+Additionally, qBittorrent runs and provides the same features on all major platforms (Linux, macOS, Windows, OS/2, FreeBSD).
 
 qBittorrent is based on the Qt toolkit and [libtorrent-rasterbar](http://www.libtorrent.org) library.
 
@@ -79,7 +79,7 @@ If you want to help in translating qBittorrent, see these [instructions](http://
 * IP Filtering (eMule & PeerGuardian format compatible)
 * IPv6 compliant
 * UPnP / NAT-PMP port forwarding support
-* Available on all platforms: Windows, Linux, Mac OS X, FreeBSD, OS/2
+* Available on all platforms: Windows, Linux, macOS, FreeBSD, OS/2
 * Available in [~70 languages](https://www.transifex.com/sledgehammer999/qbittorrent/)
 
 ** Go ahead and try qBittorrent, you won't regret it! **


### PR DESCRIPTION
**OS X** was renamed to **macOS** in 2016 https://en.wikipedia.org/wiki/MacOS#macOS