### PR TITLE
Add Catalina to the macOS section title

### DIFF
--- a/download.php
+++ b/download.php
@@ -89,7 +89,7 @@
 <br/>
 
 
-<h3>Sierra / High Sierra / Mojave</h3>
+<h3>Sierra / High Sierra / Mojave / Catalina</h3>
 <div class="flexbox">
   <div class="box1">
     <img src="img/os/macoslogo.png" alt="macOS icon"/>


### PR DESCRIPTION
macOS Catalina is already released. I used the app on it and it's working fine. We should add the new OS version to the section title as well.