### PR TITLE
4.2.3 requires 10.13/sierra

### DIFF
--- a/download.php
+++ b/download.php
@@ -74,7 +74,7 @@
 <br/>
 
 
-<h3>Sierra / High Sierra / Mojave / Catalina</h3>
+<h3>High Sierra / Mojave / Catalina</h3>
 <div class="flexbox">
   <div class="box1">
     <img src="img/os/macoslogo.png" alt="macOS icon"/>


### PR DESCRIPTION
4.2.3 no longer launching on Mac 10.12.6, requires 10.13+ Updating OS list to reflect this.