### PR TITLE
Change pacman -Sy to -S

### DIFF
--- a/download.php
+++ b/download.php
@@ -305,7 +305,7 @@
   qBittorrent is officially packaged on <a href="https://www.archlinux.org/">ArchLinux</a>.
   To install, simply type the following commands:
   <div class="codePart" style="width:540px; margin:10px 10px 10px 5px; padding:5px;">
-    sudo pacman -Sy qbittorrent
+    sudo pacman -S qbittorrent
   </div>
   Package information <a href="https://www.archlinux.org/packages/?q=qbittorrent">here</a>.<br/><br/>
   For development, you can get PKGBUILD from Arch User Repository (AUR) and build it yourself:<br/>


### PR DESCRIPTION
Partial upgrades are unsupported and are prone to cause issues with the system.
A more thorough explanation can be read [here on the Arch Wiki](https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported). As only qbittorent should be installed, `pacman -S` is a better choice.