### PR TITLE
download.php: Qt 6 builds are 64-bit only

### DIFF
--- a/download.php
+++ b/download.php
@@ -34,10 +34,10 @@
     </p>
     <p>
       <br/><br/>
-      <strong>Semi-experimental</strong> version based on Qt6. Needs Windows 10+.
+      <strong>Semi-experimental</strong> version based on Qt6. Needs Windows 10+ (64-bit only).
     </p>
     <p>
-      <strong>Download link: <a href="https://www.fosshub.com/qBittorrent.html">32-bit &amp; 64-bit installers</a> / <a href="https://www.fosshub.com/qBittorrent.html">PGP signature</a></strong> (FossHub)<br/>
+      <strong>Download link: <a href="https://www.fosshub.com/qBittorrent.html">64-bit installer</a> / <a href="https://www.fosshub.com/qBittorrent.html">PGP signature</a></strong> (FossHub)<br/>
       <sub>Mirror link: <a href="https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.4.0/qbittorrent_4.4.0_qt6_x64_setup.exe/download">64-bit installer</a> / <a href="https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.4.0/qbittorrent_4.4.0_qt6_x64_setup.exe.asc/download">PGP signature</a> (SourceForge)</sub>
     </p>
     <table>


### PR DESCRIPTION
Hi there!  
Since [Qt has no plans to officially support 32-bit Qt 6](https://www.qt.io/blog/qt6-development-hosts-and-targets#:~:text=Development%20hosts%20and%20targets%20in%20Qt%205.15%20that%20are%20not%20planned%20in%20Qt%206), I guess qBittorrent will not release any 32-bit Qt 6 builds. Thus, I made some changes on the download page to make the text more clear.