### PR TITLE
Fix typo in News page

### DIFF
--- a/news.md
+++ b/news.md
@@ -3,7 +3,7 @@
 qBittorrent v4.5.0 was released.<br>
 A lot of work has gone into this release which isn't necessarily reflected in the changelog below (code improvements, rewritings and refactorings). Special thank you to people that were helpful in other useful areas like testing and bug hunting: [@thalieht](https://github.com/thalieht), [@xavier2k6](https://github.com/xavier2k6), [@PriitUring](https://github.com/PriitUring), [@oorzkws](https://github.com/oorzkws)<br>
 Notable features: New icon theme, new color theme and better startup time when using many torrents.<br>
-**WINDOWS:** Only 64-bit builds will offered from now on.<br>
+**WINDOWS:** Only 64-bit builds will be offered from now on.<br>
 **NOTE:** The default builds for all OSs switched to libtorrent 1.2.x from 2.0.x. Builds for libtorrent 2.0.x are also offered and are tagged with `lt20`. The switch happened due to user demand and perceived performance issues. If until now you didn't experience any performance issue then go ahead and use the `lt20` builds.
 
 <details>


### PR DESCRIPTION
Was missing word "be". Should be written: "will be offered", not "will offered".