### PR TITLE
replace broken menu links

### DIFF
--- a/_site/donate.html
+++ b/_site/donate.html
@@ -20,10 +20,10 @@
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
     <![endif]-->
 
-    <link rel="dns-prefetch" href="http://git.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://bugs.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://wiki.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://forum.qbittorrent.org">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/wiki">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/wiki">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/discussions">
   </head>
   <body>
     <span id="forkongithub">
@@ -39,12 +39,12 @@
         <ul>
           <li class="first"><a href="./">Home</a></li>
           <li><a href="news">News</a></li>
-          <li><a href="http://forum.qbittorrent.org" target="_blank">Forum</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/discussions" target="_blank">Forum</a></li>
           <li><a href="download">Download</a></li>
           <li><a href="https://sourceforge.net/projects/qbittorrent/#screenshots">Screenshots</a></li>
-          <li><a href="http://wiki.qbittorrent.org" target="_blank">Wiki</a></li>
-          <li><a href="http://git.qbittorrent.org" target="_blank">Development</a></li>
-          <li><a href="http://bugs.qbittorrent.org" target="_blank">Bugs</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/wiki" target="_blank">Wiki</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent" target="_blank">Development</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/issues" target="_blank">Bugs</a></li>
         </ul>
       </div>
 

--- a/_site/download.html
+++ b/_site/download.html
@@ -20,10 +20,10 @@
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
     <![endif]-->
 
-    <link rel="dns-prefetch" href="http://git.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://bugs.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://wiki.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://forum.qbittorrent.org">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/wiki">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/wiki">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/discussions">
   </head>
   <body>
     <span id="forkongithub">
@@ -39,12 +39,12 @@
         <ul>
           <li class="first"><a href="./">Home</a></li>
           <li><a href="news">News</a></li>
-          <li><a href="http://forum.qbittorrent.org" target="_blank">Forum</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/discussions" target="_blank">Forum</a></li>
           <li><a href="download">Download</a></li>
           <li><a href="https://sourceforge.net/projects/qbittorrent/#screenshots">Screenshots</a></li>
-          <li><a href="http://wiki.qbittorrent.org" target="_blank">Wiki</a></li>
-          <li><a href="http://git.qbittorrent.org" target="_blank">Development</a></li>
-          <li><a href="http://bugs.qbittorrent.org" target="_blank">Bugs</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/wiki" target="_blank">Wiki</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent" target="_blank">Development</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/issues" target="_blank">Bugs</a></li>
         </ul>
       </div>
 

--- a/_site/index.html
+++ b/_site/index.html
@@ -20,10 +20,10 @@
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
     <![endif]-->
 
-    <link rel="dns-prefetch" href="http://git.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://bugs.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://wiki.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://forum.qbittorrent.org">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/wiki">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/wiki">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/discussions">
   </head>
   <body>
     <span id="forkongithub">
@@ -39,12 +39,12 @@
         <ul>
           <li class="first"><a href="./">Home</a></li>
           <li><a href="news">News</a></li>
-          <li><a href="http://forum.qbittorrent.org" target="_blank">Forum</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/discussions" target="_blank">Forum</a></li>
           <li><a href="download">Download</a></li>
           <li><a href="https://sourceforge.net/projects/qbittorrent/#screenshots">Screenshots</a></li>
-          <li><a href="http://wiki.qbittorrent.org" target="_blank">Wiki</a></li>
-          <li><a href="http://git.qbittorrent.org" target="_blank">Development</a></li>
-          <li><a href="http://bugs.qbittorrent.org" target="_blank">Bugs</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/wiki" target="_blank">Wiki</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent" target="_blank">Development</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/issues" target="_blank">Bugs</a></li>
         </ul>
       </div>
 
@@ -63,7 +63,7 @@ The qBittorrent project aims to provide an open-source software alternative to Â
 <p>qBittorrent is developed by <a href="team">volunteers</a> in their spare time.</p>
 <p>If you like this piece of software, please make a donation and help it survive.</p>
 <p>Donation info <a href="donate">here</a>.</p>
-<p>If you want to help in translating qBittorrent, see these <a href="http://wiki.qbittorrent.org/How-to-translate-qBittorrent" target="_blank">instructions</a>.</p>
+<p>If you want to help in translating qBittorrent, see these <a href="https://github.com/qbittorrent/qBittorrent/wiki/How-to-translate-qBittorrent" target="_blank">instructions</a>.</p>
 <h3>qBittorrent Features</h3>
 <ul>
 <li>Polished ÂµTorrent-like User Interface</li>

--- a/_site/news.html
+++ b/_site/news.html
@@ -20,10 +20,10 @@
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
     <![endif]-->
 
-    <link rel="dns-prefetch" href="http://git.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://bugs.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://wiki.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://forum.qbittorrent.org">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/wiki">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/wiki">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/discussions">
   </head>
   <body>
     <span id="forkongithub">
@@ -39,12 +39,12 @@
         <ul>
           <li class="first"><a href="./">Home</a></li>
           <li><a href="news">News</a></li>
-          <li><a href="http://forum.qbittorrent.org" target="_blank">Forum</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/discussions" target="_blank">Forum</a></li>
           <li><a href="download">Download</a></li>
           <li><a href="https://sourceforge.net/projects/qbittorrent/#screenshots">Screenshots</a></li>
-          <li><a href="http://wiki.qbittorrent.org" target="_blank">Wiki</a></li>
-          <li><a href="http://git.qbittorrent.org" target="_blank">Development</a></li>
-          <li><a href="http://bugs.qbittorrent.org" target="_blank">Bugs</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/wiki" target="_blank">Wiki</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent" target="_blank">Development</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/issues" target="_blank">Bugs</a></li>
         </ul>
       </div>
 

--- a/_site/team.html
+++ b/_site/team.html
@@ -20,10 +20,10 @@
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
     <![endif]-->
 
-    <link rel="dns-prefetch" href="http://git.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://bugs.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://wiki.qbittorrent.org">
-    <link rel="dns-prefetch" href="http://forum.qbittorrent.org">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/wiki">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/wiki">
+    <link rel="dns-prefetch" href="https://github.com/qbittorrent/qBittorrent/discussions">
   </head>
   <body>
     <span id="forkongithub">
@@ -39,12 +39,12 @@
         <ul>
           <li class="first"><a href="./">Home</a></li>
           <li><a href="news">News</a></li>
-          <li><a href="http://forum.qbittorrent.org" target="_blank">Forum</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/discussions" target="_blank">Forum</a></li>
           <li><a href="download">Download</a></li>
           <li><a href="https://sourceforge.net/projects/qbittorrent/#screenshots">Screenshots</a></li>
-          <li><a href="http://wiki.qbittorrent.org" target="_blank">Wiki</a></li>
-          <li><a href="http://git.qbittorrent.org" target="_blank">Development</a></li>
-          <li><a href="http://bugs.qbittorrent.org" target="_blank">Bugs</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/wiki" target="_blank">Wiki</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent" target="_blank">Development</a></li>
+          <li><a href="https://github.com/qbittorrent/qBittorrent/issues" target="_blank">Bugs</a></li>
         </ul>
       </div>
 

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ If you like this piece of software, please make a donation and help it survive.
 
 Donation info [here](donate).
 
-If you want to help in translating qBittorrent, see these <a href="http://wiki.qbittorrent.org/How-to-translate-qBittorrent" target="_blank">instructions</a>.
+If you want to help in translating qBittorrent, see these <a href="https://github.com/qbittorrent/qBittorrent/wiki/How-to-translate-qBittorrent" target="_blank">instructions</a>.
 
 
 ### qBittorrent Features


### PR DESCRIPTION
The menu links for the subdomains of qbittorrent.org are broken are are just showing a default apache server splash page. I replaced the broken links with their working github counterparts.