### PR TITLE
Fix release news typos

### DIFF
--- a/_site/news.html
+++ b/_site/news.html
@@ -53,7 +53,7 @@
               <div class="stretcher" id="StretchHome">
 <p><a href="news_feed.atom"><img src="img/rss-color.svg" class="rss" alt="Atom feed"></a></p>
 <h3 id="sun-sep-29th-2024---qbittorrent-v5.0.0-release" tabindex="-1"><a class="header-anchor" href="#sun-sep-29th-2024---qbittorrent-v5.0.0-release">Sun Sep 29th 2024 - qBittorrent v5.0.0 release</a></h3>
-<p>qBittorrent v5.0.0 was release.<br>
+<p>qBittorrent v5.0.0 was released.<br>
 Thanks to all the people involved, those that are named in the changelog below and those that are not.<br>
 Apart from the people mentioned below in the changelog, there are many who have contributed to code refactorings, internal fixes, bug triaging, testing new code and features, and general help.</p>
 <details>
@@ -170,7 +170,7 @@ Apart from the people mentioned below in the changelog, there are many who have 
 <li><a href="https://github.com/qbittorrent/qBittorrent/compare/release-4.6.7...release-5.0.0">Full changes</a></li>
 </ul>
 <h3 id="mon-sep-16th-2024---qbittorrent-v4.6.7-release" tabindex="-1"><a class="header-anchor" href="#mon-sep-16th-2024---qbittorrent-v4.6.7-release">Mon Sep 16th 2024 - qBittorrent v4.6.7 release</a></h3>
-<p>qBittorrent v4.6.7 was release.<br>
+<p>qBittorrent v4.6.7 was released.<br>
 This is a last minute release before v5.0.0 for a bug that slipped into v4.6.6. The coming weekend the stable release of v5.0.0 should happen.</p>
 <details>
 <summary>Library versions</summary>

--- a/_site/news_feed.atom
+++ b/_site/news_feed.atom
@@ -7,7 +7,7 @@
   </contributor>
   <link href="https://www.qbittorrent.org/news_feed.atom" rel="self"/>
   <link href="https://www.qbittorrent.org/news"/>
-  <updated>2024-09-30T01:06:34.231Z</updated>
+  <updated>2024-10-13T12:41:07.007Z</updated>
   <entry>
     <title>qBittorrent v5.0.0 release</title>
     <id>https://www.qbittorrent.org/news#sun-sep-29th-2024---qbittorrent-v5.0.0-release</id>
@@ -17,7 +17,7 @@
     <author>
       <name>The qBittorrent project</name>
     </author>
-    <content type="html">&lt;p&gt;qBittorrent v5.0.0 was release.&lt;br&gt;
+    <content type="html">&lt;p&gt;qBittorrent v5.0.0 was released.&lt;br&gt;
 Thanks to all the people involved, those that are named in the changelog below and those that are not.&lt;br&gt;
 Apart from the people mentioned below in the changelog, there are many who have contributed to code refactorings, internal fixes, bug triaging, testing new code and features, and general help.&lt;/p&gt;
 &lt;details&gt;
@@ -143,7 +143,7 @@ Apart from the people mentioned below in the changelog, there are many who have 
     <author>
       <name>The qBittorrent project</name>
     </author>
-    <content type="html">&lt;p&gt;qBittorrent v4.6.7 was release.&lt;br&gt;
+    <content type="html">&lt;p&gt;qBittorrent v4.6.7 was released.&lt;br&gt;
 This is a last minute release before v5.0.0 for a bug that slipped into v4.6.6. The coming weekend the stable release of v5.0.0 should happen.&lt;/p&gt;
 &lt;details&gt;
 &lt;summary&gt;Library versions&lt;/summary&gt;

--- a/src/news.md
+++ b/src/news.md
@@ -6,7 +6,7 @@ permalink: "{{ page.filePathStem }}.html"
 
 ### Sun Sep 29th 2024 - qBittorrent v5.0.0 release
 
-qBittorrent v5.0.0 was release.<br>
+qBittorrent v5.0.0 was released.<br>
 Thanks to all the people involved, those that are named in the changelog below and those that are not.<br>
 Apart from the people mentioned below in the changelog, there are many who have contributed to code refactorings, internal fixes, bug triaging, testing new code and features, and general help.
 
@@ -125,7 +125,7 @@ v5.0.0 changelog:
 
 ### Mon Sep 16th 2024 - qBittorrent v4.6.7 release
 
-qBittorrent v4.6.7 was release.<br>
+qBittorrent v4.6.7 was released.<br>
 This is a last minute release before v5.0.0 for a bug that slipped into v4.6.6. The coming weekend the stable release of v5.0.0 should happen.
 
 <details>


### PR DESCRIPTION
Fix two 'was release' -> 'was released' typos.

Earlier release news do not have this typo.