### PR TITLE
Rename provided CI Builds from "nightly" to "latest development"

### DIFF
--- a/_site/download.html
+++ b/_site/download.html
@@ -150,7 +150,7 @@
     </table>
     </details>
     <p class="releaseParagraph">
-      <strong><a href="https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_windows.yaml?query=branch%3Amaster" title="GitHub (require registration)">Download nightly builds</a></strong>
+      <strong><a href="https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_windows.yaml?query=branch%3Amaster+event%3Apush" title="GitHub (require registration)">Download latest development builds</a></strong> (registered GitHub account required)
     </p>
   </div>
 </div>
@@ -234,7 +234,7 @@
     </table>
     </details>
     <p class="releaseParagraph">
-      <strong><a href="https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_macos.yaml?query=branch%3Amaster" title="GitHub (require registration)">Download nightly builds</a></strong>
+      <strong><a href="https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_macos.yaml?query=branch%3Amaster+event%3Apush" title="GitHub (require registration)">Download latest development builds</a></strong> (registered GitHub account required)
     </p>
     <br>
     <div class="downloadNotesDiv">
@@ -325,7 +325,7 @@
     </table>
     </details>
     <p class="releaseParagraph">
-      <strong><a href="https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_ubuntu.yaml?query=branch%3Amaster" title="GitHub (require registration)">Download nightly builds</a></strong>
+      <strong><a href="https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_ubuntu.yaml?query=branch%3Amaster+event%3Apush" title="GitHub (require registration)">Download latest development builds</a></strong> (registered GitHub account required)
     </p>
     <br>
     <div class="downloadNotesDiv">

--- a/src/download.liquid
+++ b/src/download.liquid
@@ -127,7 +127,7 @@ src:
     </table>
     </details>
     <p class="releaseParagraph">
-      <strong><a href="https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_windows.yaml?query=branch%3Amaster" title="GitHub (require registration)">Download nightly builds</a></strong>
+      <strong><a href="https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_windows.yaml?query=branch%3Amaster+event%3Apush" title="GitHub (require registration)">Download latest development builds</a></strong> (registered GitHub account required)
     </p>
   </div>
 </div>
@@ -211,7 +211,7 @@ src:
     </table>
     </details>
     <p class="releaseParagraph">
-      <strong><a href="https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_macos.yaml?query=branch%3Amaster" title="GitHub (require registration)">Download nightly builds</a></strong>
+      <strong><a href="https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_macos.yaml?query=branch%3Amaster+event%3Apush" title="GitHub (require registration)">Download latest development builds</a></strong> (registered GitHub account required)
     </p>
     <br>
     <div class="downloadNotesDiv">
@@ -302,7 +302,7 @@ src:
     </table>
     </details>
     <p class="releaseParagraph">
-      <strong><a href="https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_ubuntu.yaml?query=branch%3Amaster" title="GitHub (require registration)">Download nightly builds</a></strong>
+      <strong><a href="https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_ubuntu.yaml?query=branch%3Amaster+event%3Apush" title="GitHub (require registration)">Download latest development builds</a></strong> (registered GitHub account required)
     </p>
     <br>
     <div class="downloadNotesDiv">


### PR DESCRIPTION
* Rename provided CI Builds from "nightly" to "latest development"
"nightly builds" are the wrong term to use as the builds are not created on a nightly schedule.
* Modified CI build links to ensure only `merged` builds from qBittorrent's own `master` branch are shown.
* Clearly state that a (registered GitHub account is required), not just a `hint` on download link.